### PR TITLE
Fix version equality in requirements.txt so pip can understand it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 numpy>=1.16.0
 scipy
 scikit-learn
-pandas=0.24.2
+pandas==0.24.2
 matplotlib
 astropy
-pymc3=3.6
+pymc3==3.6
 theano>=1.0.4
 mkl-service
 corner


### PR DESCRIPTION
As reported by Toshi Kasuga: pip installation currently fails. The suspected culprit is currently how I set the versions for pandas and pymc3. 